### PR TITLE
Restart container unless stopped, update README for compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Please note that Emulator for Azure App Configuration is unofficial and not endo
 ## Getting Started
 
 ```shell
-docker-compose up -d
+docker compose up -d
 ```
 
 (Leave off the `-d` to run in your current terminal instead of in background/detached mode.)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - DATABASE_PATH=/var/lib/azureappconfigurationemulator/emulator.db
       - SSL_CERTIFICATE_KEY_PATH=/var/lib/azureappconfigurationemulator/emulator.key
       - SSL_CERTIFICATE_CERT_PATH=/var/lib/azureappconfigurationemulator/emulator.crt
+    restart: unless-stopped
 volumes:
   data:
   data-protection-keys:


### PR DESCRIPTION
This updates the docker-compose.yml to restart the container unless stopped manually.

This also updates the README to use `docker compose` instead of the older `docker-compose`.